### PR TITLE
Remove android:allowBackup="true"

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.truizlop.sectionedrecyclerview">
 
-    <application android:allowBackup="true" android:label="@string/app_name">
+    <application android:label="@string/app_name">
 
     </application>
 


### PR DESCRIPTION
Allow apps using the library to select their own backup option without needing to override it. Libraries should't use allowBackup in theeir manifest. This provokes a build error in recent versions of the Gradle plugin when the application sets the value to false.

Temporary workaround is to add `tools:replace="android:allowBackup"` to the _application_ tag in the app's manifest.

I'm creating the pull request against master because I don't see there is any other branch for development.
