### PR TITLE
Setups indices on attached instead of constructor

### DIFF
--- a/library/src/main/java/com/truizlop/sectionedrecyclerview/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/com/truizlop/sectionedrecyclerview/SectionedRecyclerViewAdapter.java
@@ -44,9 +44,14 @@ public abstract class SectionedRecyclerViewAdapter<H extends RecyclerView.ViewHo
     public SectionedRecyclerViewAdapter() {
         super();
         registerAdapterDataObserver(new SectionDataObserver());
-        notifyDataSetChanged();
     }
 
+    @Override
+    public void onAttachedToRecyclerView(RecyclerView recyclerView) {
+        super.onAttachedToRecyclerView(recyclerView);
+        setupIndices();
+    }
+    
     /**
      * Returns the sum of number of items for each section plus headers and footers if they
      * are provided.
@@ -244,7 +249,6 @@ public abstract class SectionedRecyclerViewAdapter<H extends RecyclerView.ViewHo
     class SectionDataObserver extends RecyclerView.AdapterDataObserver{
         @Override
         public void onChanged() {
-            super.onChanged();
             setupIndices();
         }
     }


### PR DESCRIPTION
> Removes the call to setupIndices() indirectly invoked by notifyDataSetChanged() in the constructor. Instead, the initial setup of indices get's done in onAttachedToRecyclerView(), when the adapter has been created and initialized probably.
> 
> This fixes the problem with calling child's getSectionCount() when it depends on non-null fields initialization at construction time, since the parent constructor get's called before the child's.

Fixes #3 and #4

Also, I removed `super.onChanged();` in SectionDataObserver since the parent method is empty. 

`onAttachedToRecyclerView()` is the best place for the initialization that I could find, can't assure it is the best one. But I don't see a reason not to use it.

Hope it helps!
