### PR TITLE
Reset/setup indices also on range changes.

### DIFF
--- a/library/src/main/java/com/truizlop/sectionedrecyclerview/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/com/truizlop/sectionedrecyclerview/SectionedRecyclerViewAdapter.java
@@ -251,5 +251,25 @@ public abstract class SectionedRecyclerViewAdapter<H extends RecyclerView.ViewHo
         public void onChanged() {
             setupIndices();
         }
+
+        @Override
+        public void onItemRangeChanged(int positionStart, int itemCount) {
+            setupIndices();
+        }
+
+        @Override
+        public void onItemRangeInserted(int positionStart, int itemCount) {
+            setupIndices();
+        }
+
+        @Override
+        public void onItemRangeRemoved(int positionStart, int itemCount) {
+            setupIndices();
+        }
+
+        @Override
+        public void onItemRangeMoved(int fromPosition, int toPosition, int itemCount) {
+            setupIndices();
+        }
     }
 }


### PR DESCRIPTION
This fixes indices not being setup again when only an item range (or even just one item) changes, not the whole data set.
