### PR TITLE
Expose section and position within a section for a given absolute position

### DIFF
--- a/library/src/main/java/com/truizlop/sectionedrecyclerview/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/com/truizlop/sectionedrecyclerview/SectionedRecyclerViewAdapter.java
@@ -51,7 +51,7 @@ public abstract class SectionedRecyclerViewAdapter<H extends RecyclerView.ViewHo
         super.onAttachedToRecyclerView(recyclerView);
         setupIndices();
     }
-    
+
     /**
      * Returns the sum of number of items for each section plus headers and footers if they
      * are provided.
@@ -191,6 +191,14 @@ public abstract class SectionedRecyclerViewAdapter<H extends RecyclerView.ViewHo
             setupIndices();
         }
         return isFooter[position];
+    }
+
+    public int getSectionForPosition(int position) {
+        return sectionForPosition[position];
+    }
+
+    public int getPositionWithinSection(int positon) {
+        return positionWithinSection[positon];
     }
 
     protected boolean isSectionHeaderViewType(int viewType){

--- a/library/src/main/java/com/truizlop/sectionedrecyclerview/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/com/truizlop/sectionedrecyclerview/SectionedRecyclerViewAdapter.java
@@ -197,8 +197,8 @@ public abstract class SectionedRecyclerViewAdapter<H extends RecyclerView.ViewHo
         return sectionForPosition[position];
     }
 
-    public int getPositionWithinSection(int positon) {
-        return positionWithinSection[positon];
+    public int getPositionWithinSection(int position) {
+        return positionWithinSection[position];
     }
 
     protected boolean isSectionHeaderViewType(int viewType){


### PR DESCRIPTION
A use case for exposing these properties is determining the column span of a particular position of a `RecyclerView` using a `GridLayoutManager`.  Using your own custom `GridLayoutManager.SpanSizeLookup` to implement your own `getSpanSize(int)` only provides you with an absolute position, and if you want to determine different span sizes for your non-header/footer items, it helps to know which section a particular absolute position is in, or what position in a section a given absolute position is.
