### PR TITLE
Change visibility of getSectionCount/getItemCountForSection

### DIFF
--- a/library/src/main/java/com/truizlop/sectionedrecyclerview/SectionedRecyclerViewAdapter.java
+++ b/library/src/main/java/com/truizlop/sectionedrecyclerview/SectionedRecyclerViewAdapter.java
@@ -204,12 +204,12 @@ public abstract class SectionedRecyclerViewAdapter<H extends RecyclerView.ViewHo
     /**
      * Returns the number of sections in the RecyclerView
      */
-    protected abstract int getSectionCount();
+    public abstract int getSectionCount();
 
     /**
      * Returns the number of items for a given section
      */
-    protected abstract int getItemCountForSection(int section);
+    public abstract int getItemCountForSection(int section);
 
     /**
      * Returns true if a given section should have a footer


### PR DESCRIPTION
This PR makes `getSectionCount` and `getItemCountForSection` public. This allows users to query the section count without having to subclass.